### PR TITLE
Added LANDRS SPARQL service to the stack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,11 +90,30 @@ services:
 
   demo:
     image: landrs/demo
-    build: ../demo
+    build:
+      context: ../demo
+      args:
+        - VUE_APP_AXIOS_BASE_URL=http://ld.landrs.org/${QUERIES_PATH:-ejs}
     labels:
       - traefik.http.routers.demo.rule=(Host(`ld.landrs.org`) && PathPrefix(`/demo`))
       - traefik.http.middlewares.demo-prefix.stripprefix.prefixes=/demo
       - traefik.http.routers.demo.middlewares=demo-prefix
+    networks:
+      - landrs
+
+  queries:
+    image: landrs/queries
+    build: ../queries
+    environment:
+      - SPARQL_USERNAME=${SPARQL_USERNAME}
+      - SPARQL_PASSWORD=${SPARQL_PASSWORD}
+    expose:
+      - 3000
+    labels:
+      - traefik.http.services.queries.loadbalancer.server.port=3000
+      - traefik.http.routers.queries.rule=(Host(`ld.landrs.org`) && PathPrefix(`/${QUERIES_PATH:-ejs}`))
+      - traefik.http.middlewares.queries-prefix.stripprefix.prefixes=/${QUERIES_PATH:-ejs}
+      - traefik.http.routers.queries.middlewares=queries-prefix
     networks:
       - landrs
 

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,2 @@
+SPARQL_USERNAME=fuseki_username
+SPARQL_PASSWORD=fuseki_password


### PR DESCRIPTION
In this PR we add the LANDRS SPARQL service to the docker-compose setup. The configuration now requires that we set the following environment variables to valid values to correctly build the SPARQL service:
```
SPARQL_USERNAME
SPARQL_PASSWORD
```
